### PR TITLE
Mimic 4 wire fan

### DIFF
--- a/main_test.py
+++ b/main_test.py
@@ -2,7 +2,7 @@
 Entry point for development.
 """
 
-from tesla_cooler import read_write_pulse
+from tesla_cooler import four_wire_fan
 
 
 def main() -> None:
@@ -10,4 +10,4 @@ def main() -> None:
     Run what we're testing.
     :return: None
     """
-    read_write_pulse.main()
+    four_wire_fan.main()

--- a/tesla_cooler/four_wire_fan.py
+++ b/tesla_cooler/four_wire_fan.py
@@ -1,0 +1,57 @@
+"""
+Library to interface with the four wire fan interfaces commonly present on PCs.
+"""
+
+from machine import Pin
+
+from tesla_cooler.read_write_pulse import measure_pulse_properties, write_square_wave
+
+try:
+    import typing as t  # pylint: disable=unused-import
+except ImportError:
+    pass  # we're probably on the pico if this occurs.
+
+
+def mimic_fan(
+    pwm_input_pin_index: int,
+    tachometer_output_pin_index: int,
+    state_machine_indices: "t.Tuple[int, int]",
+) -> None:
+    """
+    Sample entrypoint. Prints pulse duration periodically.
+    :return: None
+    """
+
+    state_machine_index_source = iter(state_machine_indices)
+
+    measure_pulse = measure_pulse_properties(
+        data_pin=Pin(pwm_input_pin_index, Pin.IN),
+        state_machine_index=next(state_machine_index_source),
+    )
+
+    set_frequency_hz = write_square_wave(
+        output_pin=Pin(tachometer_output_pin_index, Pin.OUT),
+        state_machine_index=next(state_machine_index_source),
+    )
+
+    while True:
+        latest_properties = measure_pulse(0.01)
+        if latest_properties is not None:
+            duty = round(latest_properties.duty_cycle, 2)
+            output = duty * 100
+            if set_frequency_hz(output):
+                print(f"Input Duty: {duty}, Set output frequency to: {output} Hz")
+        else:
+            print("No pulse detected.")
+
+
+def main() -> None:
+    """
+    Example usage of the `mimic_fan` function.
+    :return: None
+    """
+    mimic_fan(pwm_input_pin_index=0, tachometer_output_pin_index=1, state_machine_indices=(0, 1))
+
+
+if __name__ == "__main__":
+    main()

--- a/tesla_cooler/read_write_pulse/read_write_pulse_common.py
+++ b/tesla_cooler/read_write_pulse/read_write_pulse_common.py
@@ -21,15 +21,3 @@ PulseProperties = namedtuple(
         "duty_cycle",
     ],
 )
-
-SquareWaveController = namedtuple(
-    "SquareWaveController",
-    [
-        # Function that takes the frequency in HZ to drive the output square wave at.
-        "set_frequency_hz",
-        # Callable, starts creating waves if they're not being created already.
-        "enable",
-        # Callable, stops creating waves. Pin will be set high once disabled.
-        "disable",
-    ],
-)


### PR DESCRIPTION
Proves the concept that we're able to mimic a standard 4-wire fan by reading and writing square waves from the connector using PIOs. 