### PR TITLE
Pico Query Client & MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+0.4.0 - (2023-06-24)
+------------------
+
+* Introduces `pico_query_client.py`, an interface for reading sensor values back to a host
+(at this point running [GPU Temperature Logger](https://github.com/Tesla-Cooler/gpu_temperature_logger)).
+* PCC can use MCP3008 to read thermistors.
+* Can read temp values/write LED states to/from "temperature module 1.0.0" 
+
 0.3.0 - (2022-09-05)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Tesla Cooler (Software) - `tesla_cooler` 
 
+**Warning!** This project is undergoing a massive change. Until things are stable, the branch
+`silent_cooler` is the development branch for this project. 
+
 ![](./image.jpg)
 
 Firmware for the Raspberry Pi Pico to drive fans and cool NVIDIA Tesla compute GPUs.

--- a/main_prod.py
+++ b/main_prod.py
@@ -79,7 +79,7 @@ def create_cooler_callback(
         :return: None
         """
 
-        thermistor_temperature = thermistor.thermistor_temperature(
+        thermistor_temperature = thermistor.rp2040_adc_thermistor_temperature(
             pin_number=thermistor_pin, resistance_to_temperature=resistance_to_temperature
         )
 

--- a/main_test.py
+++ b/main_test.py
@@ -2,7 +2,7 @@
 Entry point for development.
 """
 
-from tesla_cooler.mcp_3008 import loop_read
+from tesla_cooler.pico_query_client import query_loop
 
 
 def main() -> None:
@@ -11,4 +11,4 @@ def main() -> None:
     :return: None
     """
 
-    loop_read()
+    query_loop()

--- a/main_test.py
+++ b/main_test.py
@@ -2,7 +2,7 @@
 Entry point for development.
 """
 
-from tesla_cooler.pico_query_client import query_loop
+from tesla_cooler.mcp_3008 import loop_read
 
 
 def main() -> None:
@@ -11,4 +11,4 @@ def main() -> None:
     :return: None
     """
 
-    query_loop()
+    loop_read()

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def prod_dependencies() -> List[str]:
 
 setup(
     name="tesla_cooler",
-    version="0.2.2",
+    version="0.4.0",
     description=(
         "Firmware for a Raspberry Pi Pico to drive fans and cool NVIDIA Tesla compute GPUs."
     ),

--- a/tesla_cooler/mcp_3008.py
+++ b/tesla_cooler/mcp_3008.py
@@ -1,0 +1,82 @@
+import machine
+from machine import SPI, Pin
+from tesla_cooler import thermistor
+
+try:
+    import typing as t  # pylint: disable=unused-import
+except ImportError:
+    pass  # we're probably on the pico if this occurs.
+
+
+def mcp3008_reader(spi: SPI, chip_select: Pin) -> "t.Callable[[int], int]":
+    """
+
+    :param spi:
+    :param chip_select:
+    :return:
+    """
+
+    # Must be same length to use `write_readinto`.
+    output_buffer = bytearray(3)
+    input_buf = bytearray(3)
+
+    output_buffer[0] = 1
+
+    chip_select.on()  # Initially disable
+
+    def read(channel: int) -> int:
+        """
+
+        :param channel:
+        :return:
+        """
+
+        chip_select.off()
+        output_buffer[1] = (1 << 7) | (channel << 4)
+        spi.write_readinto(output_buffer, input_buf)
+        chip_select.on()
+
+        return ((input_buf[1] & 0x03) << 8) | input_buf[2]
+
+    return read
+
+
+def loop_read() -> None:
+    """
+
+    :return:
+    """
+
+    cs = machine.Pin(5, machine.Pin.OUT)
+    cs.off()
+
+    spi = machine.SPI(
+        0,
+        sck=machine.Pin(2),
+        mosi=machine.Pin(3),
+        miso=machine.Pin(4),
+    )
+
+    reader = mcp3008_reader(spi, cs)
+
+    lookup = thermistor.read_resistance_to_temperature(thermistor.B2550_3950K_10K_JSON_PATH)
+
+    while True:
+
+        adc_count = reader(0)
+
+        print(f"ADC count: {adc_count}")
+
+        resistance = thermistor.thermistor_resistance(
+            adc_count=adc_count,
+            v_in_count=thermistor.U_10_MAX,
+        )
+
+        print(f"Resistance: {resistance}")
+
+        temperature = thermistor.thermistor_temperature_resistance(
+            resistance=resistance,
+            resistance_to_temperature=lookup
+        )
+
+        print(f"Temperature: {temperature}")

--- a/tesla_cooler/pico_query_client.py
+++ b/tesla_cooler/pico_query_client.py
@@ -88,11 +88,11 @@ def configure_temperature_reader(
             return TemperatureReading(
                 zone_1=temperature_module_readings.tmp1,
                 zone_2=temperature_module_readings.tmp2,
-                intake=thermistor.thermistor_temperature(
+                intake=thermistor.rp2040_adc_thermistor_temperature(
                     pin_number=INTAKE_PIN,
                     resistance_to_temperature=resistance_to_temp_environment,
                 ),
-                exhaust=thermistor.thermistor_temperature(
+                exhaust=thermistor.rp2040_adc_thermistor_temperature(
                     pin_number=INTAKE_PIN,  # TODO: Wrong!
                     resistance_to_temperature=resistance_to_temp_environment,
                 ),
@@ -112,19 +112,19 @@ def configure_temperature_reader(
             )
 
             return TemperatureReading(
-                zone_1=thermistor.thermistor_temperature(
+                zone_1=thermistor.rp2040_adc_thermistor_temperature(
                     pin_number=Z1_PIN,
                     resistance_to_temperature=resistance_to_temp_washer,
                 ),
-                zone_2=thermistor.thermistor_temperature(
+                zone_2=thermistor.rp2040_adc_thermistor_temperature(
                     pin_number=Z2_PIN,
                     resistance_to_temperature=resistance_to_temp_washer,
                 ),
-                intake=thermistor.thermistor_temperature(
+                intake=thermistor.rp2040_adc_thermistor_temperature(
                     pin_number=INTAKE_PIN,
                     resistance_to_temperature=resistance_to_temp_environment,
                 ),
-                exhaust=thermistor.thermistor_temperature(
+                exhaust=thermistor.rp2040_adc_thermistor_temperature(
                     pin_number=INTAKE_PIN,  # TODO: Wrong!
                     resistance_to_temperature=resistance_to_temp_environment,
                 ),

--- a/tesla_cooler/pico_query_client.py
+++ b/tesla_cooler/pico_query_client.py
@@ -30,12 +30,6 @@ CLIENT_INFO = {
     "zone_sensors_type": "Washer Thermistor",
 }
 
-# Pin mappings
-I2C_SCL_PIN = 21
-I2C_SDA_PIN = 20
-ADDRESS_1_PIN = 19
-ADDRESS_0_PIN = 18
-
 
 TemperatureReading = namedtuple(
     "TemperatureReading",
@@ -131,18 +125,18 @@ def configure_temperature_reader(
     return output
 
 
-def query_loop(temperature_module_mode: bool = False) -> None:
+def query_loop() -> None:
     """
     Entrypoint for the Pico Query client. Waits for messages to arrive on the external UART
     interface and replies in kind. Currently doesn't handle errors well.
-    :param temperature_module_mode: If the reported values should be from the temperature module
-    via I2C or not (meaning it'll return converted ADC values). This needs to match the physical
-    circuit so tread with caution.
     :return: None
     """
 
     uart_port = UART(0, baudrate=BAUD, tx=Pin(16), rx=Pin(17), bits=8, parity=None, stop=1)
-    read_sensors = configure_temperature_reader(temperature_module_mode=temperature_module_mode)
+    read_sensors = configure_temperature_reader(temperature_module_mode=False)
+
+    print(f"Client Info: {CLIENT_INFO}")
+    print(f"Sample Reading: {read_sensors()}")
 
     while True:
         if uart_port.any():

--- a/tesla_cooler/temperature_module/__init__.py
+++ b/tesla_cooler/temperature_module/__init__.py
@@ -1,5 +1,5 @@
 """
-docker run --rm --gpus '"device=0,1"' gpu_burn 500
+Export high-level controls for the temperature module board.
 """
 
 
@@ -37,7 +37,7 @@ def configured_temperature_reader() -> "t.Tuple[I2C, t.Callable[[], TemperatureM
     i2c = I2C(0, scl=Pin(I2C_SCL), sda=Pin(I2C_SDA), freq=100_000)
 
     return i2c, temperature_sensor.create_reader(
-        i2c=i2c, tmp1_address=0b1001100, tmp2_address=0b1001110
+        i2c=i2c, tmp1_address=0b1001_100, tmp2_address=0b1001_110
     )
 
 

--- a/tesla_cooler/temperature_module/__init__.py
+++ b/tesla_cooler/temperature_module/__init__.py
@@ -8,6 +8,7 @@ from time import sleep
 from machine import I2C, Pin
 
 from tesla_cooler.temperature_module import io_expander, temperature_sensor
+from tesla_cooler.temperature_module.temperature_sensor import TemperatureModuleReadings
 
 try:
     import typing as t  # pylint: disable=unused-import
@@ -21,10 +22,10 @@ ADDRESS_1 = 19
 ADDRESS_0 = 18
 
 
-def proof_of_concept() -> None:
+def configured_temperature_reader() -> "t.Tuple[I2C, t.Callable[[], TemperatureModuleReadings]]":
     """
-
-    :return:
+    Given the current global pin mapping, enable and return a temperature reader.
+    :return: A tuple (configured i2c interface, temperature reader).
     """
 
     address_0 = Pin(ADDRESS_0, Pin.OUT)
@@ -35,9 +36,19 @@ def proof_of_concept() -> None:
 
     i2c = I2C(0, scl=Pin(I2C_SCL), sda=Pin(I2C_SDA), freq=100_000)
 
-    reader = temperature_sensor.create_reader(
+    return i2c, temperature_sensor.create_reader(
         i2c=i2c, tmp1_address=0b1001100, tmp2_address=0b1001110
     )
+
+
+def proof_of_concept() -> None:
+    """
+
+    :return:
+    """
+
+    i2c, reader = configured_temperature_reader()
+
     io_writer = io_expander.create_io_writer(i2c=i2c, address=0b0100100)
 
     while True:

--- a/tesla_cooler/thermistor.py
+++ b/tesla_cooler/thermistor.py
@@ -40,8 +40,8 @@ def thermistor_resistance(
     samples: int = DEFAULT_THERMISTOR_SAMPLES,
 ) -> float:
     """
-    Compute the resistance of the thermistor at the given PIN.
-    :param pin: The ADC interface that is associated with the pin connected to the thermistor.
+    Convert ADC counts into resistance.
+    :param adc_count: The ADC interface that is associated with the pin connected to the thermistor.
     :param pulldown_resistance: The value of the pulldown resistor in ohms.
     :param v_in_count: The ADC count (in the u16 number space) for V_in, the max value that could
     be read from the ADC.
@@ -92,14 +92,14 @@ def read_resistance_to_temperature(
 
 
 def thermistor_temperature_resistance(
-    resistance, resistance_to_temperature: Dict[float, float]
+    resistance: float, resistance_to_temperature: Dict[float, float]
 ) -> float:
     """
-    Read the temperature off of a thermistor attached the given pin.
-    :param pin_number: The pin connected to the thermistor.
+    Given a resistance and lookup, convert to temperature.
+    :param resistance: Thermistor resistance.
     :param resistance_to_temperature: A dict mapping resistance values to their corresponding
     temperature. Units are ohms and degrees Celsius.
-    :return: A function that when called returns the current temperature of the thermistor.
+    :return: Temperature in degrees Celsius.
     """
 
     return resistance_to_temperature[
@@ -114,11 +114,12 @@ def rp2040_adc_thermistor_temperature(
     pin_number: int, resistance_to_temperature: Dict[float, float]
 ) -> float:
     """
+    Convenience wrapper to read the temperature of a thermistor attached to an rp2040 ADC pin.
     Read the temperature off of a thermistor attached the given pin.
     :param pin_number: The pin connected to the thermistor.
     :param resistance_to_temperature: A dict mapping resistance values to their corresponding
     temperature. Units are ohms and degrees Celsius.
-    :return: A function that when called returns the current temperature of the thermistor.
+    :return: Temperature in degrees Celsius.
     """
 
     return thermistor_temperature_resistance(

--- a/tesla_cooler/thermistor.py
+++ b/tesla_cooler/thermistor.py
@@ -17,6 +17,7 @@ from tesla_cooler.pure_python_itertools import float_mean
 
 RESISTANCE_OF_PULLDOWN = 10_000
 U_16_MAX = 65535
+U_10_MAX = 1023
 
 # Determined experimentally
 DEFAULT_THERMISTOR_SAMPLES = 10
@@ -32,24 +33,24 @@ B2585_3984K_10K_JSON_PATH = (
 )
 
 
-def _thermistor_resistance(
-    pin: ADC,
+def thermistor_resistance(
+    adc_count: int,
     pulldown_resistance: int = RESISTANCE_OF_PULLDOWN,
-    vin_count: int = U_16_MAX,
+    v_in_count: int = U_16_MAX,
     samples: int = DEFAULT_THERMISTOR_SAMPLES,
 ) -> float:
     """
     Compute the resistance of the thermistor at the given PIN.
     :param pin: The ADC interface that is associated with the pin connected to the thermistor.
     :param pulldown_resistance: The value of the pulldown resistor in ohms.
-    :param vin_count: The ADC count (in the u16 number space) for V_in, the max value that could
+    :param v_in_count: The ADC count (in the u16 number space) for V_in, the max value that could
     be read from the ADC.
     :param samples: The number of samples to take to average for the measurement.
     :return: The resistance in Ohms as a float.
     """
     return float_mean(
         [
-            float((pulldown_resistance * (vin_count / pin.read_u16())) - pulldown_resistance)
+            float((pulldown_resistance * (v_in_count / adc_count)) - pulldown_resistance)
             for _ in range(samples)
         ]
     )
@@ -90,7 +91,9 @@ def read_resistance_to_temperature(
     return resistance_to_temperature
 
 
-def thermistor_temperature(pin_number: int, resistance_to_temperature: Dict[float, float]) -> float:
+def thermistor_temperature_resistance(
+    resistance, resistance_to_temperature: Dict[float, float]
+) -> float:
     """
     Read the temperature off of a thermistor attached the given pin.
     :param pin_number: The pin connected to the thermistor.
@@ -101,6 +104,24 @@ def thermistor_temperature(pin_number: int, resistance_to_temperature: Dict[floa
 
     return resistance_to_temperature[
         _closest_to_value(
-            _thermistor_resistance(pin=ADC(pin_number)), list(resistance_to_temperature.keys())
+            resistance,
+            list(resistance_to_temperature.keys()),
         )
     ]
+
+
+def rp2040_adc_thermistor_temperature(
+    pin_number: int, resistance_to_temperature: Dict[float, float]
+) -> float:
+    """
+    Read the temperature off of a thermistor attached the given pin.
+    :param pin_number: The pin connected to the thermistor.
+    :param resistance_to_temperature: A dict mapping resistance values to their corresponding
+    temperature. Units are ohms and degrees Celsius.
+    :return: A function that when called returns the current temperature of the thermistor.
+    """
+
+    return thermistor_temperature_resistance(
+        resistance=thermistor_resistance(adc_count=ADC(pin_number).read_u16()),
+        resistance_to_temperature=resistance_to_temperature,
+    )


### PR DESCRIPTION
* Introduces `pico_query_client.py`, an interface for reading sensor values back to a host
(at this point running [GPU Temperature Logger](https://github.com/Tesla-Cooler/gpu_temperature_logger)).
* PCC can use MCP3008 to read thermistors.